### PR TITLE
add fulcro tempid and transit require to ensure record class generation

### DIFF
--- a/src/conduit/handler/transit_format.clj
+++ b/src/conduit/handler/transit_format.clj
@@ -1,6 +1,8 @@
 (ns conduit.handler.transit-format
   (:require [muuntaja.format.transit :as mt]
-            [integrant.core :as ig])
+            [integrant.core :as ig]
+            [fulcro.tempid]
+            [fulcro.transit])
   (:import  [fulcro.tempid TempId]
             [com.cognitect.transit ReadHandler]
             [fulcro.transit TempIdHandler]))


### PR DESCRIPTION
While this isn't necessary for the realword-fulcro, will be a time saver if someone is trying to use transit_format.clj to experiment in their own project eg. not using the mutations.clj yet